### PR TITLE
reduce allowed regions to where agents are supported

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -8,28 +8,13 @@ param environmentName string
 @minLength(1)
 @description('Location for all resources')
 // Look for desired models on the availability table:
-// https://learn.microsoft.com/azure/ai-services/openai/concepts/models#global-standard-model-availability
+// Agents must be supported in the region
+// https://learn.microsoft.com/azure/ai-services/agents/concepts/model-region-support
 @allowed([
-  'australiaeast'
-  'brazilsouth'
-  'canadaeast'
   'eastus'
   'eastus2'
-  'francecentral'
-  'germanywestcentral'
-  'japaneast'
-  'koreacentral'
-  'northcentralus'
-  'norwayeast'
-  'polandcentral'
-  'spaincentral'
-  'southafricanorth'
-  'southcentralus'
-  'southindia'
   'swedencentral'
   'switzerlandnorth'
-  'uksouth'
-  'westeurope'
   'westus'
   'westus3'
 ])


### PR DESCRIPTION
I tried to deploy the project and it failed with a message like `Agents is not enabled in current region`

Looking into https://learn.microsoft.com/azure/ai-services/agents/concepts/model-region-support the list of regions with support to create agents is limited.

This PR reduces the list to only those where it is currently possible to create agents for gpt-4o-mini (model used in template)