### PR TITLE
Adding quota check for ai models

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -5,22 +5,26 @@ targetScope = 'subscription'
 @description('Name of the the environment which is used to generate a short unique hash used in all resources.')
 param environmentName string
 
-@minLength(1)
 @description('Location for all resources')
-// Look for desired models on the availability table:
-// Agents must be supported in the region
+// Based on the model, creating an agent is not supported in all regions. 
+// The combination of allowed and usageName below is for AZD to check AI model gpt-4o-mini quota only for the allowed regions for creating an agent.
+// If using different models, update the SKU,capacity depending on the model you use.
 // https://learn.microsoft.com/azure/ai-services/agents/concepts/model-region-support
 @allowed([
   'eastus'
   'eastus2'
   'swedencentral'
-  'switzerlandnorth'
   'westus'
   'westus3'
 ])
 @metadata({
   azd: {
     type: 'location'
+    // quota-validation for ai models: gpt-4o-mini & text-embedding-3-small
+    usageName: [
+      'OpenAI.GlobalStandard.gpt-4o-mini,30'
+      'OpenAI.GlobalStandard.text-embedding-3-small,30'
+    ]
   }
 })
 param location string


### PR DESCRIPTION
This update introduces an AI quota verification mechanism for the default AI modules utilized by the template.

The quota verification is integrated with the `allowed locations` feature, which filters the location list to include only those where creating Agents with `gpt-4o-mini` is feasible.