### PR TITLE
Howie/resolve quota

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -7,7 +7,17 @@ metadata:
   template: azd-get-started-with-ai-agents@1.0.0
 
 hooks:
-  preup:
+  preprovision:
+    posix:
+      shell: sh
+      run: chmod u+r+x ./scripts/set_default_models.sh; chmod u+r+x ./scripts/resolve_model_quota.sh; ./scripts/set_default_models.sh
+      interactive: true
+      continueOnError: false
+    windows:
+      shell: pwsh
+      run: ./scripts/set_default_models.ps1
+      interactive: true
+      continueOnError: false      
   postprovision:
     windows:
       shell: pwsh

--- a/docs/deploy_customization.md
+++ b/docs/deploy_customization.md
@@ -59,7 +59,7 @@ azd env set AZURE_AI_AGENT_MODEL_VERSION 2024-07-18
 
 ### Setting capacity and deployment SKU
 
-For quota regions, you may find yourself needing to modify the default capacity and deployment SKU. The default tokens per minute deployed in this template is 50,000. 
+For quota regions, you may find yourself needing to modify the default capacity and deployment SKU using environment variables as below. The default tokens per minute deployed in this template is 80,000 for agent model and 50,000 for the embedding model that is enough for all operations.  If the region has quota less the these numbers, it will reduce the capacity down to the region limit or 30,000 whichever higher that is enough for simple testings. However, If the region has less than 30,000, it will reduce the capacity to 1,000 to ensure the deployment will success but runtime will have quota issues.  You are expect to correct to resolve the capacity manually.
 
 Change the capacity (in thousands of tokens per minute) of the agent deployment:
 

--- a/docs/deploy_customization.md
+++ b/docs/deploy_customization.md
@@ -59,9 +59,9 @@ azd env set AZURE_AI_AGENT_MODEL_VERSION 2024-07-18
 
 ### Setting capacity and deployment SKU
 
-For quota regions, you may find yourself needing to modify the default capacity and deployment SKU using environment variables as below. The default tokens per minute deployed in this template is 80,000 for agent model and 50,000 for the embedding model that is enough for all operations.  If the region has quota less the these numbers, it will reduce the capacity down to the region limit or 30,000 whichever higher that is enough for simple testings. However, If the region has less than 30,000, it will reduce the capacity to 1,000 to ensure the deployment will success but runtime will have quota issues.  You are expect to correct to resolve the capacity manually.
+For quota regions, you may find yourself needing to modify the default capacity and deployment SKU using environment variables as below. The default tokens per minute deployed in this template is 80,000 for agent model and 50,000 for the embedding model that is enough for all operations.  If the region has quota less the these numbers, you will be prompt to input a lower capacity up to the available limit.
 
-Change the capacity (in thousands of tokens per minute) of the agent deployment:
+Change the default capacity (in thousands of tokens per minute) of the agent deployment:
 
 ```shell
 azd env set AZURE_AI_AGENT_DEPLOYMENT_CAPACITY 50
@@ -73,7 +73,7 @@ Change the SKU of the agent deployment:
 azd env set AZURE_AI_AGENT_DEPLOYMENT_SKU Standard
 ```
 
-Change the capacity (in thousands of tokens per minute) of the embeddings deployment:
+Change the default capacity (in thousands of tokens per minute) of the embeddings deployment:
 
 ```shell
 azd env set AZURE_AI_EMBED_DEPLOYMENT_CAPACITY 50

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -60,40 +60,40 @@
       "value": "${AZURE_EXISTING_AGENT_ID}"
     },
     "agentDeploymentName": {
-      "value": "${AZURE_AI_AGENT_MODEL_NAME=gpt-4o-mini}"
+      "value": "${AZURE_AI_AGENT_MODEL_NAME}"
     },
     "agentModelFormat": {
-      "value": "${AZURE_AI_AGENT_MODEL_FORMAT=OpenAI}"
+      "value": "${AZURE_AI_AGENT_MODEL_FORMAT}"
     },
     "agentModelName": {
-      "value": "${AZURE_AI_AGENT_MODEL_NAME=gpt-4o-mini}"
+      "value": "${AZURE_AI_AGENT_MODEL_NAME}"
     },
     "agentModelVersion": {
-      "value": "${AZURE_AI_AGENT_MODEL_VERSION=2024-07-18}"
+      "value": "${AZURE_AI_AGENT_MODEL_VERSION}"
     },
     "agentDeploymentSku": {
-      "value": "${AZURE_AI_AGENT_DEPLOYMENT_SKU=GlobalStandard}"
+      "value": "${AZURE_AI_AGENT_DEPLOYMENT_SKU}"
     },
     "agentDeploymentCapacity": {
-      "value": "${AZURE_AI_AGENT_DEPLOYMENT_CAPACITY=30}"
+      "value": "${AZURE_AI_AGENT_DEPLOYMENT_CAPACITY}"
     },
     "embeddingDeploymentName": {
-      "value": "${AZURE_AI_EMBED_DEPLOYMENT_NAME=text-embedding-3-small}"
+      "value": "${AZURE_AI_EMBED_DEPLOYMENT_NAME}"
     },
     "embedModelFormat": {
-      "value": "${AZURE_AI_EMBED_MODEL_FORMAT=OpenAI}"
+      "value": "${AZURE_AI_EMBED_MODEL_FORMAT}"
     },
     "embedModelName": {
-      "value": "${AZURE_AI_EMBED_MODEL_NAME=text-embedding-3-small}"
+      "value": "${AZURE_AI_EMBED_MODEL_NAME}"
     },
     "embedModelVersion": {
-      "value": "${AZURE_AI_EMBED_MODEL_VERSION=1}"
+      "value": "${AZURE_AI_EMBED_MODEL_VERSION}"
     },
     "embedDeploymentSku": {
-      "value": "${AZURE_AI_EMBED_DEPLOYMENT_SKU=Standard}"
+      "value": "${AZURE_AI_EMBED_DEPLOYMENT_SKU}"
     },
     "embedDeploymentCapacity": {
-      "value": "${AZURE_AI_EMBED_DEPLOYMENT_CAPACITY=30}"
+      "value": "${AZURE_AI_EMBED_DEPLOYMENT_CAPACITY}"
     },
     "embeddingDeploymentDimensions": {
       "value": "${AZURE_AI_EMBED_DIMENSIONS=100}"

--- a/scripts/resolve_model_quota.ps1
+++ b/scripts/resolve_model_quota.ps1
@@ -1,0 +1,76 @@
+param (
+    [string]$Location,
+    [string]$Model,
+    [string]$DeploymentType = "Standard",
+    [string]$CapacityEnvVarName,
+    [int]$IdealCapacity,
+    [int]$MinCapacity
+)
+
+# Verify all required parameters are provided
+$MissingParams = @()
+
+if (-not $Location) {
+    $MissingParams += "location"
+}
+
+if (-not $Model) {
+    $MissingParams += "model"
+}
+
+if (-not $IdealCapacity) {
+    $MissingParams += "capacity"
+}
+
+if (-not $DeploymentType) {
+    $MissingParams += "deployment-type"
+}
+
+if ($MissingParams.Count -gt 0) {
+    Write-Error "❌ ERROR: Missing required parameters: $($MissingParams -join ', ')"
+    Write-Host "Usage: .\resolve_model_quota.ps1 -Location <LOCATION> -Model <MODEL> -IdealCapacity <CAPACITY> -MinCapacity <CAPACITY> -CapacityEnvVarName <ENV_VAR_NAME> [-DeploymentType <DEPLOYMENT_TYPE>]"
+    exit 1
+}
+
+if ($DeploymentType -ne "Standard" -and $DeploymentType -ne "GlobalStandard") {
+    Write-Error "❌ ERROR: Invalid deployment type: $DeploymentType. Allowed values are 'Standard' or 'GlobalStandard'."
+    exit 1
+}
+
+$ModelType = "OpenAI.$DeploymentType.$Model"
+
+Write-Host "🔍 Checking quota for $ModelType in $Location ..."
+
+# Get model quota information
+$ModelInfo = az cognitiveservices usage list --location $Location --query "[?name.value=='$ModelType']" --output json | ConvertFrom-Json
+
+if (-not $ModelInfo) {
+    Write-Error "❌ ERROR: No quota information found for model: $Model in location: $Location for model type: $ModelType."
+    exit 1
+}
+
+if ($ModelInfo) {
+    $CurrentValue = ($ModelInfo | Where-Object { $_.name.value -eq $ModelType }).currentValue
+    $Limit = ($ModelInfo | Where-Object { $_.name.value -eq $ModelType }).limit
+
+    $CurrentValue = [int]($CurrentValue -replace '\.0+$', '') # Remove decimals
+    $Limit = [int]($Limit -replace '\.0+$', '') # Remove decimals
+
+    $Available = $Limit - $CurrentValue
+    Write-Host "✅ Model available - Model: $ModelType | Used: $CurrentValue | Limit: $Limit | Available: $Available"
+
+
+    if ($Available -lt 1) {
+        Write-Error "❌ ERROR: Insufficient quota for model: $Model in location: $Location. Available: $Available, Requested: $IdealCapacit."
+        exit 1
+    } elseif ($Available -lt $IdealCapacity) {
+        $newCapacity = 1
+        if ($Available -ge $MinCapacity) {
+            $newCapacity = $Available
+        }
+        azd env set $CapacityEnvVarName $newCapacity
+        Write-Error "❌ ERROR: Insufficient quota for model: $Model in location: $Location. Available: $Available, Requested: $IdealCapacity, Downgrade quota to: $newCapacity."
+    } else {
+        Write-Host "✅ Sufficient quota for model: $Model in location: $Location. Available: $Available, Requested: $IdealCapacity."
+    }
+}

--- a/scripts/resolve_model_quota.ps1
+++ b/scripts/resolve_model_quota.ps1
@@ -1,7 +1,8 @@
 param (
     [string]$Location,
     [string]$Model,
-    [string]$DeploymentType = "Standard",
+    [string]$Format,
+    [string]$DeploymentType,
     [string]$CapacityEnvVarName,
     [int]$Capacity
 )
@@ -21,13 +22,17 @@ if (-not $Capacity) {
     $MissingParams += "capacity"
 }
 
+if (-not $Format) {
+    $MissingParams += "format"
+}
+
 if (-not $DeploymentType) {
     $MissingParams += "deployment-type"
 }
 
 if ($MissingParams.Count -gt 0) {
     Write-Error "❌ ERROR: Missing required parameters: $($MissingParams -join ', ')"
-    Write-Host "Usage: .\resolve_model_quota.ps1 -Location <LOCATION> -Model <MODEL> -Capacity <CAPACITY> -CapacityEnvVarName <ENV_VAR_NAME> [-DeploymentType <DEPLOYMENT_TYPE>]"
+    Write-Host "Usage: .\resolve_model_quota.ps1 -Location <LOCATION> -Model <MODEL> -Format <FORMAT> -Capacity <CAPACITY> -CapacityEnvVarName <ENV_VAR_NAME> [-DeploymentType <DEPLOYMENT_TYPE>]"
     exit 1
 }
 
@@ -36,7 +41,7 @@ if ($DeploymentType -ne "Standard" -and $DeploymentType -ne "GlobalStandard") {
     exit 1
 }
 
-$ModelType = "OpenAI.$DeploymentType.$Model"
+$ModelType = "$Format.$DeploymentType.$Model"
 
 Write-Host "🔍 Checking quota for $ModelType in $Location ..."
 

--- a/scripts/resolve_model_quota.sh
+++ b/scripts/resolve_model_quota.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Initialize variables
+Location=""
+Model=""
+DeploymentType="Standard"
+CapacityEnvVarName=""
+IdealCapacity=""
+MinCapacity=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -Location)
+            Location="$2"
+            shift 2
+            ;;
+        -Model)
+            Model="$2"
+            shift 2
+            ;;
+        -DeploymentType)
+            DeploymentType="$2"
+            shift 2
+            ;;
+        -CapacityEnvVarName)
+            CapacityEnvVarName="$2"
+            shift 2
+            ;;
+        -IdealCapacity)
+            IdealCapacity="$2"
+            shift 2
+            ;;
+        -MinCapacity)
+            MinCapacity="$2"
+            shift 2
+            ;;
+        *)
+            echo "❌ ERROR: Unknown parameter: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Check for missing required parameters
+MissingParams=()
+[[ -z "$Location" ]] && MissingParams+=("location")
+[[ -z "$Model" ]] && MissingParams+=("model")
+[[ -z "$IdealCapacity" ]] && MissingParams+=("capacity")
+[[ -z "$DeploymentType" ]] && MissingParams+=("deployment-type")
+
+if [[ ${#MissingParams[@]} -gt 0 ]]; then
+    echo "❌ ERROR: Missing required parameters: ${MissingParams[*]}"
+    echo "Usage: ./resolve_model_quota.sh -Location <Location> -Model <Model> -IdealCapacity <CAPACITY> -MinCapacity <CAPACITY> -CapacityEnvVarName <ENV_VAR_NAME> [-DeploymentType <DeploymentType>]"
+    exit 1
+fi
+
+if [[ "$DeploymentType" != "Standard" && "$DeploymentType" != "GlobalStandard" ]]; then
+    echo "❌ ERROR: Invalid deployment type: $DeploymentType. Allowed values are 'Standard' or 'GlobalStandard'."
+    exit 1
+fi
+
+ModelType="OpenAI.$DeploymentType.$Model"
+
+echo "🔍 Checking quota for $ModelType in $Location ..."
+
+ModelInfo=$(az cognitiveservices usage list --location "$Location" --query "[?name.value=='$ModelType']" --output json | tr '[:upper:]' '[:lower:]')
+
+if [ -z "$ModelInfo" ]; then
+    echo "❌ ERROR: No quota information found for model: $Model in location: $Location for model type: $ModelType."
+    exit 1
+fi
+
+if [ -n "$ModelInfo" ]; then
+    CurrentValue=$(echo "$ModelInfo" | awk -F': ' '/"currentvalue"/ {print $2}' | tr -d ',' | tr -d ' ')
+    Limit=$(echo "$ModelInfo" | awk -F': ' '/"limit"/ {print $2}' | tr -d ',' | tr -d ' ')
+
+    CurrentValue=${CurrentValue:-0}
+    Limit=${Limit:-0}
+
+    CurrentValue=$(echo "$CurrentValue" | cut -d'.' -f1)
+    Limit=$(echo "$Limit" | cut -d'.' -f1)
+
+    Available=$((Limit - CurrentValue))
+    echo "✅ Model available - Model: $ModelType | Used: $CurrentValue | Limit: $Limit | Available: $Available"
+
+    if (( Available < 1 )); then
+        echo "❌ ERROR: Insufficient quota for model: $Model in location: $Location. Available: $Available, Requested: $IdealCapacity."
+        exit 1
+    elif (( Available < IdealCapacity )); then
+        newCapacity=1
+        if (( Available >= MinCapacity )); then
+            newCapacity=$Available
+        fi
+        echo "🔧 Setting environment variable $CapacityEnvVarName to $newCapacity ..."
+        azd env set "$CapacityEnvVarName" "$newCapacity"
+        echo "❌ ERROR: Insufficient quota. Requested: $IdealCapacity. Downgraded to: $newCapacity."
+    else
+        echo "✅ Sufficient quota for model: $Model in location: $Location. Available: $Available, Requested: $IdealCapacity."
+    fi
+fi

--- a/scripts/resolve_model_quota.sh
+++ b/scripts/resolve_model_quota.sh
@@ -3,7 +3,8 @@
 # Initialize variables
 Location=""
 Model=""
-DeploymentType="Standard"
+Format=""
+DeploymentType=""
 CapacityEnvVarName=""
 Capacity=""
 
@@ -30,6 +31,10 @@ while [[ $# -gt 0 ]]; do
             Capacity="$2"
             shift 2
             ;;
+        -Format)
+            Format="$2"
+            shift 2
+            ;;
         *)
             echo "❌ ERROR: Unknown parameter: $1"
             exit 1
@@ -46,7 +51,7 @@ MissingParams=()
 
 if [[ ${#MissingParams[@]} -gt 0 ]]; then
     echo "❌ ERROR: Missing required parameters: ${MissingParams[*]}"
-    echo "Usage: ./resolve_model_quota.sh -Location <Location> -Model <Model> -Capacity <CAPACITY> -CapacityEnvVarName <ENV_VAR_NAME> [-DeploymentType <DeploymentType>]"
+    echo "Usage: ./resolve_model_quota.sh -Location <Location> -Model <Model> -Format <Format> -Capacity <CAPACITY> -CapacityEnvVarName <ENV_VAR_NAME> [-DeploymentType <DeploymentType>]"
     exit 1
 fi
 
@@ -55,7 +60,7 @@ if [[ "$DeploymentType" != "Standard" && "$DeploymentType" != "GlobalStandard" ]
     exit 1
 fi
 
-ModelType="OpenAI.$DeploymentType.$Model"
+ModelType="$Format.$DeploymentType.$Model"
 
 echo "🔍 Checking quota for $ModelType in $Location ..."
 

--- a/scripts/set_default_models.ps1
+++ b/scripts/set_default_models.ps1
@@ -24,13 +24,13 @@ $defaultEnvVars = @{
     AZURE_AI_EMBED_MODEL_FORMAT = 'OpenAI'
     AZURE_AI_EMBED_MODEL_VERSION = '1'
     AZURE_AI_EMBED_DEPLOYMENT_SKU = 'Standard'
-    AZURE_AI_EMBED_DEPLOYMENT_CAPACITY = '500000'
+    AZURE_AI_EMBED_DEPLOYMENT_CAPACITY = '50'
     AZURE_AI_AGENT_DEPLOYMENT_NAME = 'gpt-4o-mini'
     AZURE_AI_AGENT_MODEL_NAME = 'gpt-4o-mini'
     AZURE_AI_AGENT_MODEL_VERSION = '2024-07-18'
     AZURE_AI_AGENT_MODEL_FORMAT = 'OpenAI'
     AZURE_AI_AGENT_DEPLOYMENT_SKU = 'GlobalStandard'
-    AZURE_AI_AGENT_DEPLOYMENT_CAPACITY = '800000'
+    AZURE_AI_AGENT_DEPLOYMENT_CAPACITY = '80'
 }
 
 $envVars = @{}
@@ -93,10 +93,11 @@ foreach ($deployment in $aiModelDeployments) {
     $name = $deployment.name
     $model = $deployment.model.name
     $type = $deployment.sku.name
+    $format = $deployment.model.format
     $capacity = $deployment.sku.capacity
     $capacity_env_var_name = $deployment.capacity_env_var_name
     Write-Host "🔍 Validating model deployment: $name ..."
-    & .\scripts\resolve_model_quota.ps1 -Location $Location -Model $model -Capacity $capacity -CapacityEnvVarName $capacity_env_var_name -DeploymentType $type
+    & .\scripts\resolve_model_quota.ps1 -Location $Location -Model $model -Format $format -Capacity $capacity -CapacityEnvVarName $capacity_env_var_name -DeploymentType $type
 
     # Check if the script failed
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/set_default_models.ps1
+++ b/scripts/set_default_models.ps1
@@ -1,22 +1,19 @@
-param (
-    [string]$SubscriptionId,
-    [string]$Location
-)
-# Verify all required parameters are provided
-$MissingParams = @()
+$SubscriptionId = ([System.Environment]::GetEnvironmentVariable('AZURE_SUBSCRIPTION_ID', "Process"))
+$Location = ([System.Environment]::GetEnvironmentVariable('AZURE_LOCATION', "Process"))
+
+$Errors = 0
 
 if (-not $SubscriptionId) {
-    $MissingParams += "subscription"
+    Write-Error "❌ ERROR: Missing AZURE_SUBSCRIPTION_ID"
+    $Errors++
 }
 
 if (-not $Location) {
-    $MissingParams += "location"
+    Write-Error "❌ ERROR: Missing AZURE_LOCATION"
+    $Errors++
 }
 
-
-if ($MissingParams.Count -gt 0) {
-    Write-Error "❌ ERROR: Missing required parameters: $($MissingParams -join ', ')"
-    Write-Host "Usage: .\set_default_models.ps1 -SubscriptionId <SUBSCRIPTION_ID> -Location <LOCATION> -ModelsParameter <MODELS_PARAMETER>"
+if ($Errors -gt 0) {
     exit 1
 }
 
@@ -27,13 +24,13 @@ $defaultEnvVars = @{
     AZURE_AI_EMBED_MODEL_FORMAT = 'OpenAI'
     AZURE_AI_EMBED_MODEL_VERSION = '1'
     AZURE_AI_EMBED_DEPLOYMENT_SKU = 'Standard'
-    AZURE_AI_EMBED_DEPLOYMENT_CAPACITY = '50'
+    AZURE_AI_EMBED_DEPLOYMENT_CAPACITY = '500000'
     AZURE_AI_AGENT_DEPLOYMENT_NAME = 'gpt-4o-mini'
     AZURE_AI_AGENT_MODEL_NAME = 'gpt-4o-mini'
     AZURE_AI_AGENT_MODEL_VERSION = '2024-07-18'
     AZURE_AI_AGENT_MODEL_FORMAT = 'OpenAI'
     AZURE_AI_AGENT_DEPLOYMENT_SKU = 'GlobalStandard'
-    AZURE_AI_AGENT_DEPLOYMENT_CAPACITY = '80'
+    AZURE_AI_AGENT_DEPLOYMENT_CAPACITY = '800000'
 }
 
 $envVars = @{}
@@ -56,8 +53,7 @@ $chatDeployment = @{
     }
     sku = @{
         name = $envVars.AZURE_AI_AGENT_DEPLOYMENT_SKU
-        ideal_capacity = $envVars.AZURE_AI_AGENT_DEPLOYMENT_CAPACITY
-        min_capacity = 30
+        capacity = $envVars.AZURE_AI_AGENT_DEPLOYMENT_CAPACITY
     } 
     capacity_env_var_name = 'AZURE_AI_AGENT_DEPLOYMENT_CAPACITY'
 }
@@ -78,7 +74,7 @@ if ($useSearchService -eq 'true') {
         }
         sku = @{
             name = $envVars.AZURE_AI_EMBED_DEPLOYMENT_SKU
-            ideal_capacity = $envVars.AZURE_AI_EMBED_DEPLOYMENT_CAPACITY
+            capacity = $envVars.AZURE_AI_EMBED_DEPLOYMENT_CAPACITY
             min_capacity = 30
         }
         capacity_env_var_name = 'AZURE_AI_EMBED_DEPLOYMENT_CAPACITY'
@@ -97,11 +93,10 @@ foreach ($deployment in $aiModelDeployments) {
     $name = $deployment.name
     $model = $deployment.model.name
     $type = $deployment.sku.name
-    $ideal_capacity = $deployment.sku.ideal_capacity
-    $min_capacity = $deployment.sku.min_capacity
+    $capacity = $deployment.sku.capacity
     $capacity_env_var_name = $deployment.capacity_env_var_name
     Write-Host "🔍 Validating model deployment: $name ..."
-    & .\scripts\resolve_model_quota.ps1 -Location $Location -Model $model -IdealCapacity $ideal_capacity -MinCapacity $min_capacity -CapacityEnvVarName $capacity_env_var_name -DeploymentType $type
+    & .\scripts\resolve_model_quota.ps1 -Location $Location -Model $model -Capacity $capacity -CapacityEnvVarName $capacity_env_var_name -DeploymentType $type
 
     # Check if the script failed
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/set_default_models.ps1
+++ b/scripts/set_default_models.ps1
@@ -44,6 +44,13 @@ foreach ($key in $defaultEnvVars.Keys) {
     azd env set $key $envVars[$key]
 }
 
+# --- If we do not use existing AI Project, we don't deploy models, so skip validation ---
+$resourceId = [System.Environment]::GetEnvironmentVariable('AZURE_EXISTING_AIPROJECT_RESOURCE_ID', "Process")
+if (-not [string]::IsNullOrEmpty($resourceId)) {
+    Write-Host "✅ AZURE_EXISTING_AIPROJECT_RESOURCE_ID is set, skipping model deployment validation."
+    exit 0
+}
+
 $chatDeployment = @{
     name = $envVars.AZURE_AI_AGENT_DEPLOYMENT_NAME
     model = @{
@@ -88,6 +95,13 @@ az account set --subscription $SubscriptionId
 Write-Host "🎯 Active Subscription: $(az account show --query '[name, id]' --output tsv)"
 
 $QuotaAvailable = $true
+
+try {
+    Write-Host "🔍 Validating model deployments against quotas..."
+} catch {
+    Write-Error "❌ ERROR: Failed to validate model deployments. Ensure you have the necessary permissions."
+    exit 1
+}
 
 foreach ($deployment in $aiModelDeployments) {
     $name = $deployment.name

--- a/scripts/set_default_models.ps1
+++ b/scripts/set_default_models.ps1
@@ -1,0 +1,119 @@
+param (
+    [string]$SubscriptionId,
+    [string]$Location
+)
+# Verify all required parameters are provided
+$MissingParams = @()
+
+if (-not $SubscriptionId) {
+    $MissingParams += "subscription"
+}
+
+if (-not $Location) {
+    $MissingParams += "location"
+}
+
+
+if ($MissingParams.Count -gt 0) {
+    Write-Error "❌ ERROR: Missing required parameters: $($MissingParams -join ', ')"
+    Write-Host "Usage: .\set_default_models.ps1 -SubscriptionId <SUBSCRIPTION_ID> -Location <LOCATION> -ModelsParameter <MODELS_PARAMETER>"
+    exit 1
+}
+
+
+$defaultEnvVars = @{
+    AZURE_AI_EMBED_DEPLOYMENT_NAME = 'text-embedding-3-small'
+    AZURE_AI_EMBED_MODEL_NAME = 'text-embedding-3-small'
+    AZURE_AI_EMBED_MODEL_FORMAT = 'OpenAI'
+    AZURE_AI_EMBED_MODEL_VERSION = '1'
+    AZURE_AI_EMBED_DEPLOYMENT_SKU = 'Standard'
+    AZURE_AI_EMBED_DEPLOYMENT_CAPACITY = '50'
+    AZURE_AI_AGENT_DEPLOYMENT_NAME = 'gpt-4o-mini'
+    AZURE_AI_AGENT_MODEL_NAME = 'gpt-4o-mini'
+    AZURE_AI_AGENT_MODEL_VERSION = '2024-07-18'
+    AZURE_AI_AGENT_MODEL_FORMAT = 'OpenAI'
+    AZURE_AI_AGENT_DEPLOYMENT_SKU = 'GlobalStandard'
+    AZURE_AI_AGENT_DEPLOYMENT_CAPACITY = '80'
+}
+
+$envVars = @{}
+
+foreach ($key in $defaultEnvVars.Keys) {
+    $val = [System.Environment]::GetEnvironmentVariable($key, "Process")
+    $envVars[$key] = $val
+    if (-not $val) {
+        $envVars[$key] = $defaultEnvVars[$key]
+    }
+    azd env set $key $envVars[$key]
+}
+
+$chatDeployment = @{
+    name = $envVars.AZURE_AI_AGENT_DEPLOYMENT_NAME
+    model = @{
+        name = $envVars.AZURE_AI_AGENT_MODEL_NAME
+        version = $envVars.AZURE_AI_AGENT_MODEL_VERSION
+        format = $envVars.AZURE_AI_AGENT_MODEL_FORMAT
+    }
+    sku = @{
+        name = $envVars.AZURE_AI_AGENT_DEPLOYMENT_SKU
+        ideal_capacity = $envVars.AZURE_AI_AGENT_DEPLOYMENT_CAPACITY
+        min_capacity = 30
+    } 
+    capacity_env_var_name = 'AZURE_AI_AGENT_DEPLOYMENT_CAPACITY'
+}
+
+
+
+$aiModelDeployments = @($chatDeployment)
+
+$useSearchService = ([System.Environment]::GetEnvironmentVariable('USE_AZURE_AI_SEARCH_SERVICE', "Process"))
+
+if ($useSearchService -eq 'true') {
+    $embedDeployment = @{
+        name = $envVars.AZURE_AI_EMBED_DEPLOYMENT_NAME
+        model = @{
+            name = $envVars.AZURE_AI_EMBED_MODEL_NAME
+            version = $envVars.AZURE_AI_EMBED_MODEL_VERSION
+            format = $envVars.AZURE_AI_EMBED_MODEL_FORMAT
+        }
+        sku = @{
+            name = $envVars.AZURE_AI_EMBED_DEPLOYMENT_SKU
+            ideal_capacity = $envVars.AZURE_AI_EMBED_DEPLOYMENT_CAPACITY
+            min_capacity = 30
+        }
+        capacity_env_var_name = 'AZURE_AI_EMBED_DEPLOYMENT_CAPACITY'
+    }
+
+    $aiModelDeployments += $embedDeployment
+}
+
+
+az account set --subscription $SubscriptionId
+Write-Host "🎯 Active Subscription: $(az account show --query '[name, id]' --output tsv)"
+
+$QuotaAvailable = $true
+
+foreach ($deployment in $aiModelDeployments) {
+    $name = $deployment.name
+    $model = $deployment.model.name
+    $type = $deployment.sku.name
+    $ideal_capacity = $deployment.sku.ideal_capacity
+    $min_capacity = $deployment.sku.min_capacity
+    $capacity_env_var_name = $deployment.capacity_env_var_name
+    Write-Host "🔍 Validating model deployment: $name ..."
+    & .\scripts\resolve_model_quota.ps1 -Location $Location -Model $model -IdealCapacity $ideal_capacity -MinCapacity $min_capacity -CapacityEnvVarName $capacity_env_var_name -DeploymentType $type
+
+    # Check if the script failed
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "❌ ERROR: Quota validation failed for model deployment: $name"
+        $QuotaAvailable = $false
+    }
+}
+
+
+if (-not $QuotaAvailable) {
+    exit 1
+} else {
+    Write-Host "✅ All model deployments passed quota validation successfully."
+    exit 0
+}

--- a/scripts/set_default_models.sh
+++ b/scripts/set_default_models.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -SubscriptionId) SubscriptionId="$2"; shift ;;
+        -Location) Location="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+    
+# Validate required parameters
+MissingParams=()
+[ -z "$SubscriptionId" ] && MissingParams+=("subscription")
+[ -z "$Location" ] && MissingParams+=("location")
+
+if [ ${#MissingParams[@]} -gt 0 ]; then
+    echo "❌ ERROR: Missing required parameters: ${MissingParams[*]}"
+    echo "Usage: ./set_default_models.sh -SubscriptionId <SUBSCRIPTION_ID> -Location <LOCATION>"
+    exit 1
+fi
+
+
+
+# Default environment variables
+declare -A defaultEnvVars=(
+    [AZURE_AI_EMBED_DEPLOYMENT_NAME]="text-embedding-3-small"
+    [AZURE_AI_EMBED_MODEL_NAME]="text-embedding-3-small"
+    [AZURE_AI_EMBED_MODEL_FORMAT]="OpenAI"
+    [AZURE_AI_EMBED_MODEL_VERSION]="1"
+    [AZURE_AI_EMBED_DEPLOYMENT_SKU]="Standard"
+    [AZURE_AI_EMBED_DEPLOYMENT_CAPACITY]="50"
+    [AZURE_AI_AGENT_DEPLOYMENT_NAME]="gpt-4o-mini"
+    [AZURE_AI_AGENT_MODEL_NAME]="gpt-4o-mini"
+    [AZURE_AI_AGENT_MODEL_VERSION]="2024-07-18"
+    [AZURE_AI_AGENT_MODEL_FORMAT]="OpenAI"
+    [AZURE_AI_AGENT_DEPLOYMENT_SKU]="GlobalStandard"
+    [AZURE_AI_AGENT_DEPLOYMENT_CAPACITY]="80"
+)
+
+# Set environment variables
+for key in "${!defaultEnvVars[@]}"; do
+    val="${!key}"
+    if [ -z "$val" ]; then
+        val="${defaultEnvVars[$key]}"
+        export $key="$val"
+    fi
+    azd env set "$key" "$val"
+done
+
+# Build chat deployment
+chatDeployment=(
+    "$AZURE_AI_AGENT_DEPLOYMENT_NAME"
+    "$AZURE_AI_AGENT_MODEL_NAME"
+    "$AZURE_AI_AGENT_MODEL_VERSION"
+    "$AZURE_AI_AGENT_MODEL_FORMAT"
+    "$AZURE_AI_AGENT_DEPLOYMENT_SKU"
+    "$AZURE_AI_AGENT_DEPLOYMENT_CAPACITY"
+    "AZURE_AI_AGENT_DEPLOYMENT_CAPACITY"
+)
+
+aiModelDeployments=("${chatDeployment[@]}")
+
+
+# Optionally add embed deployment
+if [[ "${USE_AZURE_AI_SEARCH_SERVICE,,}" == "true" ]]; then
+    embedDeployment=(
+        "$AZURE_AI_EMBED_DEPLOYMENT_NAME"
+        "$AZURE_AI_EMBED_MODEL_NAME"
+        "$AZURE_AI_EMBED_MODEL_VERSION"
+        "$AZURE_AI_EMBED_MODEL_FORMAT"
+        "$AZURE_AI_EMBED_DEPLOYMENT_SKU"
+        "$AZURE_AI_EMBED_DEPLOYMENT_CAPACITY"
+        "AZURE_AI_EMBED_DEPLOYMENT_CAPACITY"
+    )
+    aiModelDeployments+=("${embedDeployment[@]}")
+fi
+# Set subscription
+az account set --subscription "$SubscriptionId"
+echo "🎯 Active Subscription: $(az account show --query '[name, id]' --output tsv)"
+
+
+# Validate quota
+QuotaAvailable=true
+for ((i=0; i<${#aiModelDeployments[@]}; i+=7)); do
+    name="${aiModelDeployments[i]}"
+    model="${aiModelDeployments[i+1]}"
+    version="${aiModelDeployments[i+2]}"
+    format="${aiModelDeployments[i+3]}"
+    sku="${aiModelDeployments[i+4]}"
+    ideal_capacity="${aiModelDeployments[i+5]}"
+    capacity_env="${aiModelDeployments[i+6]}"
+    min_capacity=30
+
+    echo "🔍 Validating model deployment: $name ..."
+    ./scripts/resolve_model_quota.sh -Location "$Location" -Model "$model" -IdealCapacity "$ideal_capacity" -MinCapacity "$min_capacity" -CapacityEnvVarName "$capacity_env" -DeploymentType "$sku"
+    if [ $? -ne 0 ]; then
+        echo "❌ ERROR: Quota validation failed for model deployment: $name"
+        QuotaAvailable=false
+    fi
+done
+
+
+if [ "$QuotaAvailable" = false ]; then
+    exit 1
+else
+    echo "✅ All model deployments passed quota validation successfully."
+    exit 0
+fi
+

--- a/scripts/set_default_models.sh
+++ b/scripts/set_default_models.sh
@@ -29,13 +29,13 @@ declare -A defaultEnvVars=(
     [AZURE_AI_EMBED_MODEL_FORMAT]="OpenAI"
     [AZURE_AI_EMBED_MODEL_VERSION]="1"
     [AZURE_AI_EMBED_DEPLOYMENT_SKU]="Standard"
-    [AZURE_AI_EMBED_DEPLOYMENT_CAPACITY]="500000"
+    [AZURE_AI_EMBED_DEPLOYMENT_CAPACITY]="50"
     [AZURE_AI_AGENT_DEPLOYMENT_NAME]="gpt-4o-mini"
     [AZURE_AI_AGENT_MODEL_NAME]="gpt-4o-mini"
     [AZURE_AI_AGENT_MODEL_VERSION]="2024-07-18"
     [AZURE_AI_AGENT_MODEL_FORMAT]="OpenAI"
     [AZURE_AI_AGENT_DEPLOYMENT_SKU]="GlobalStandard"
-    [AZURE_AI_AGENT_DEPLOYMENT_CAPACITY]="800000"
+    [AZURE_AI_AGENT_DEPLOYMENT_CAPACITY]="80"
 )
 
 # --- Set Env Vars and azd env ---
@@ -85,11 +85,12 @@ QuotaAvailable=true
 
 # --- Validate Quota ---
 for entry in "${aiModelDeployments[@]}"; do
-    IFS="|" read -r name model model_version model_format type capacity capacity_env_var_name <<< "$entry"
+    IFS="|" read -r name model model_version format type capacity capacity_env_var_name <<< "$entry"
     echo "🔍 Validating model deployment: $name ..."
     ./scripts/resolve_model_quota.sh \
         -Location "$Location" \
         -Model "$model" \
+        -Format "$format" \
         -Capacity "$capacity" \
         -CapacityEnvVarName "$capacity_env_var_name" \
         -DeploymentType "$type"

--- a/scripts/set_default_models.sh
+++ b/scripts/set_default_models.sh
@@ -49,6 +49,13 @@ for key in "${!defaultEnvVars[@]}"; do
     azd env set "$key" "$val"
 done
 
+# --- If we do not use existing AI Project, we don't deploy models, so skip validation ---
+resourceId="${AZURE_EXISTING_AIPROJECT_RESOURCE_ID}"
+if [ -n "$resourceId" ]; then
+    echo "✅ AZURE_EXISTING_AIPROJECT_RESOURCE_ID is set, skipping model deployment validation."
+    exit 0
+fi
+
 # --- Build Chat Deployment ---
 chatDeployment_name="${AZURE_AI_AGENT_DEPLOYMENT_NAME}"
 chatDeployment_model_name="${AZURE_AI_AGENT_MODEL_NAME}"

--- a/scripts/setup_credential.ps1
+++ b/scripts/setup_credential.ps1
@@ -1,27 +1,27 @@
 # Prompt for username with validation
 do {
-    $username = Read-Host -Prompt 'Create a new username for the web app (no spaces, at least 1 character)'
+    $username = Read-Host -Prompt '👤 Create a new username for the web app (no spaces, at least 1 character)'
     $usernameInvalid = $false
     if ([string]::IsNullOrWhiteSpace($username)) {
-        Write-Warning "Username cannot be empty or consist only of whitespace."
+        Write-Warning "❌ Username cannot be empty or consist only of whitespace."
         $usernameInvalid = $true
     } elseif ($username -match '\s') {
-        Write-Warning "Username cannot contain spaces."
+        Write-Warning "❌ Username cannot contain spaces."
         $usernameInvalid = $true
     }
 } while ($usernameInvalid)
 
 # Prompt for password with validation
 do {
-    $password = Read-Host -Prompt 'Create a new password for the web app (no spaces, at least 1 character)' -AsSecureString
-    $confirmPassword = Read-Host -Prompt 'Confirm the new password' -AsSecureString
+    $password = Read-Host -Prompt '🔑 Create a new password for the web app (no spaces, at least 1 character)' -AsSecureString
+    $confirmPassword = Read-Host -Prompt '🔑 Confirm the new password' -AsSecureString
     $passwordInvalid = $false
 
     if ($password.Length -eq 0) {
-        Write-Warning "Password cannot be empty."
+        Write-Warning "❌ Password cannot be empty."
         $passwordInvalid = $true
     } elseif ($password.Length -ne $confirmPassword.Length) { # Quick check for length difference
-        Write-Warning "Passwords do not match."
+        Write-Warning "❌ Passwords do not match."
         $passwordInvalid = $true
     } else {
         # Convert SecureStrings to plain text for validation and comparison
@@ -32,10 +32,10 @@ do {
         $confirmPlainPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($confirmBSTR)
 
         if ($tempPlainPassword -ne $confirmPlainPassword) {
-            Write-Warning "Passwords do not match."
+            Write-Warning "❌ Passwords do not match."
             $passwordInvalid = $true
         } elseif ($tempPlainPassword -match '\s') {
-            Write-Warning "Password cannot contain spaces."
+            Write-Warning "❌ Password cannot contain spaces."
             $passwordInvalid = $true
         }
         
@@ -59,7 +59,7 @@ az account set --subscription $subscriptionId
 Write-Host "🎯 Active Subscription: $(az account show --query '[name, id]' --output tsv)"
 
 
-Write-Host "Setup username and password in the secrets..."
+Write-Host "⏳ Setup username and password in the secrets..."
 
 # Set the secret
 az containerapp secret set `
@@ -76,8 +76,8 @@ az containerapp update `
   > $null 2>&1
 
 
-Write-Host "New username and password now are in the secrets"
-Write-Host "Querying the active revision in the container app..."
+Write-Host "✅ New username and password now are in the secrets"
+Write-Host "🔍 Querying the active revision in the container app..."
 
 # Get the active revision name
 $activeRevision = az containerapp revision list `
@@ -87,11 +87,11 @@ $activeRevision = az containerapp revision list `
     --output tsv
 
 if (-not $activeRevision) {
-    Write-Host "No active revision found for the specified Container App."
+    Write-Host "❌ No active revision found for the specified Container App."
     exit 1
 }
 
-Write-Host "Restarting revision $activeRevision...."
+Write-Host "♻️ Restarting revision $activeRevision...."
 
 
 # Restart the active revision
@@ -101,4 +101,4 @@ az containerapp revision restart `
     --revision $activeRevision `
     > $null 2>&1
 
-Write-Host "Successfully restarted the revision: $activeRevision"
+Write-Host "✅ Successfully restarted the revision: $activeRevision"

--- a/scripts/setup_credential.ps1
+++ b/scripts/setup_credential.ps1
@@ -102,3 +102,5 @@ az containerapp revision restart `
     > $null 2>&1
 
 Write-Host "✅ Successfully restarted the revision: $activeRevision"
+
+exit 0

--- a/scripts/setup_credential.sh
+++ b/scripts/setup_credential.sh
@@ -78,3 +78,5 @@ az containerapp revision restart \
   > /dev/null 2>&1
 
 echo "✅ Successfully restarted the revision: $activeRevision"
+
+exit 0

--- a/scripts/setup_credential.sh
+++ b/scripts/setup_credential.sh
@@ -2,10 +2,10 @@
 
 # Prompt for username with validation
 while true; do
-  read -rp "Create a new username for the web app (no spaces, at least 1 character): " username
+  read -rp "👤 Create a new username for the web app (no spaces, at least 1 character): " username
 
   if [[ -z "$username" || "$username" =~ [[:space:]] ]]; then
-    echo "Username cannot be empty or contain spaces." >&2
+    echo "❌ Username cannot be empty or contain spaces." >&2
   else
     break
   fi
@@ -13,17 +13,17 @@ done
 
 # Prompt for password with validation
 while true; do
-  read -rsp "Create a new password for the web app (no spaces, at least 1 character): " password
+  read -rsp "🔑 Create a new password for the web app (no spaces, at least 1 character): " password
   echo
-  read -rsp "Confirm the new password: " confirmPassword
+  read -rsp "🔑 Confirm the new password: " confirmPassword
   echo
 
   if [[ -z "$password" ]]; then
-    echo "Password cannot be empty." >&2
+    echo "❌ Password cannot be empty." >&2
   elif [[ "$password" != "$confirmPassword" ]]; then
-    echo "Passwords do not match." >&2
+    echo "❌ Passwords do not match." >&2
   elif [[ "$password" =~ [[:space:]] ]]; then
-    echo "Password cannot contain spaces." >&2
+    echo "❌ Password cannot contain spaces." >&2
   else
     break
   fi
@@ -37,7 +37,7 @@ subscriptionId=$(azd env get-value AZURE_SUBSCRIPTION_ID)
 az account set --subscription $subscriptionId
 echo "🎯 Active Subscription: $(az account show --query '[name, id]' --output tsv)"
 
-echo "Setup username and password in the secrets..."
+echo "⏳ Setup username and password in the secrets..."
 
 # Set the secrets
 az containerapp secret set \
@@ -53,8 +53,8 @@ az containerapp update \
   --set-env-vars WEB_APP_USERNAME=secretref:web-app-username WEB_APP_PASSWORD=secretref:web-app-password \
   > /dev/null 2>&1
 
-echo "New username and password now are in the secrets"
-echo "Querying the active revision in the container app..."
+echo "✅ New username and password now are in the secrets"
+echo "🔍 Querying the active revision in the container app..."
 
 # Get the active revision name
 activeRevision=$(az containerapp revision list \
@@ -64,11 +64,11 @@ activeRevision=$(az containerapp revision list \
   --output tsv)
 
 if [[ -z "$activeRevision" ]]; then
-  echo "No active revision found for the specified Container App." >&2
+  echo "❌ No active revision found for the specified Container App." >&2
   exit 1
 fi
 
-echo "Restarting revision $activeRevision..."
+echo "♻️ Restarting revision $activeRevision..."
 
 # Restart the active revision
 az containerapp revision restart \
@@ -77,4 +77,4 @@ az containerapp revision restart \
   --revision "$activeRevision" \
   > /dev/null 2>&1
 
-echo "Successfully restarted the revision: $activeRevision"
+echo "✅ Successfully restarted the revision: $activeRevision"

--- a/scripts/write_env.ps1
+++ b/scripts/write_env.ps1
@@ -35,5 +35,5 @@ Add-Content -Path $envFilePath -Value "AZURE_TENANT_ID=$azureTenantId"
 Add-Content -Path $envFilePath -Value "ENABLE_AZURE_MONITOR_TRACING=$enableAzureMonitorTracing"
 Add-Content -Path $envFilePath -Value "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=$azureTracingGenAIContentRecordingEnabled"
 
-Write-Host "Please visit web app URL:"
+Write-Host "🌐 Please visit web app URL:"
 Write-Host $serviceAPIUri -ForegroundColor Cyan

--- a/scripts/write_env.sh
+++ b/scripts/write_env.sh
@@ -22,7 +22,7 @@ echo "ENABLE_AZURE_MONITOR_TRACING=$(azd env get-value ENABLE_AZURE_MONITOR_TRAC
 echo "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED=$(azd env get-value AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED)" >> $ENV_FILE_PATH
 
 
-echo "Please visit web app URL:"
+echo "🌐 Please visit web app URL:"
 echo -e "\033[0;36m$(azd env get-value SERVICE_API_URI)\033[0m"
 
 exit 0


### PR DESCRIPTION
Changed gpt-40-mini capacity to 80 and embedding to 50.
Moved default values are moved to ps1 and sh script.   
When you run azd up, the script to first populate this default values into the .env file if they are not set yet.   
Then validate the quota specified in the .env.   If they are larger than the actual available, prompt the user to input between 1 to the available.    Also expect users to abort by Ctrl-C if they want to.

Here is a demo that use way use 800000 and 500000 quota for testing and of course I lower it in this PR

<img width="884" alt="image" src="https://github.com/user-attachments/assets/3fa99c8a-7d82-495c-8255-d9a38d38ad6a" />
