### PR TITLE
fix AZURE_EXISTING_AIPROJECT_RESOURCE_ID

### DIFF
--- a/docs/deploy_customization.md
+++ b/docs/deploy_customization.md
@@ -12,7 +12,7 @@ This document describes how to customize the deployment of the Agents Chat with 
 Be default, this template provisions a new resource group along with other resources.   If you already have provisioned Azure AI Foundry and Azure AI Foundry Project, you might reuse these resources by setting:
 
 ```shell
-azd env set AZURE_EXISTING_AIPROJECT_RESOURCE_ID "https://<your-ai-services-account-name>.services.ai.azure.com/api/projects/<your-project-name>"
+azd env set AZURE_EXISTING_AIPROJECT_RESOURCE_ID "/subscriptions/<your-azure-subid>/resourceGroups/<your-rg>/providers/Microsoft.CognitiveServices/accounts/<your-ai-services-account-name>/projects/<your-project-name>"
 ```
 
 Notices that Application Insight and AI Search will not be created in this scenario.


### PR DESCRIPTION
based on the validate_env_var scripts and on the main.biceps, this variable should have this content:
    "AZURE_EXISTING_AIPROJECT_RESOURCE_ID" = '^/subscriptions/[0-9a-fA-F-]{36}/resourceGroups/[^/]+/providers/Microsoft\.CognitiveServices/accounts/[^/]+/projects/[^/]+$'