### PR TITLE
adding azure MCP and GH Copilot 4 Azure extensions in  devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
                 "ms-azuretools.vscode-bicep",
                 "ms-python.python",
                 "ms-toolsai.jupyter",
-                "GitHub.vscode-github-actions"
+                "GitHub.vscode-github-actions",
+                "ms-azuretools.vscode-azure-mcp-server",
+                "ms-azuretools.vscode-azure-github-copilot"
             ]
         }
     },


### PR DESCRIPTION
Adding 2 new extinsions for devcontainer. These exentions will help by adding MCP and Azure specific Copilot ability in the devcontainer / codespaces

- [GitHub Copilot for Azure - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azure-github-copilot)
- [Azure MCP Server - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azure-mcp-server)