### PR TITLE
Updated the pre-requisite section with (optional) step to avoid bicep runtime download error while using azd up

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,24 +33,6 @@ az bicep version   # verify installation
 
 If you prefer to use the standalone `bicep` binary, place it on your `PATH` before running `azd up`.
 
-### Quick prerequisite verification
-
-Run the validation script for your platform to confirm both environment variables and the Bicep CLI are ready:
-
-- Linux/macOS:
-
-  ```bash
-  chmod u+x ./scripts/validate_env_vars.sh
-  ./scripts/validate_env_vars.sh
-  ```
-
-- Windows PowerShell:
-
-  ```powershell
-  pwsh -File ./scripts/validate_env_vars.ps1
-  ```
-
-The script reports any missing Bicep installation or malformed environment variables so you can address them before provisioning.
 
 ### **Important Note for PowerShell Users**
 


### PR DESCRIPTION
**Instructs users** to run az bicep install/az bicep version (or provide a standalone bicep binary) before invoking azd up.
Reduces dependency on ad-hoc downloads during deployment and ensures consistent Bicep versions in all environments.

**Why It’s Important**

- Prevents broken deployments: Installing Bicep up front avoids the common “context canceled” download errors that halt provisioning.
- Saves developer time: Instead of waiting for azd up to fail midway, users get immediate feedback that their toolchain is incomplete.
- Improves reproducibility: Teams can standardize on the Azure CLI-distributed Bicep version, eliminating mismatches between local dev, Codespaces, and CI pipelines.
- Enhances documentation completeness: The deployment guide now reflects the real prerequisites for this IaC workflow, reducing friction for new adopters.

_azd up must compile every file under infra/*.bicep before provisioning. When Bicep isn’t installed locally, azd tries to download a pinned binary (v0.38.33) from downloads.bicep.azure.com. In constrained environments (Codespaces, corporate networks, intermittent connectivity) that download frequently fails, producing the failed resolving IaC provider 'bicep' error and blocking all deployments.
Users currently have no warning that Bicep is required upfront, so the failure surfaces only after several minutes of provisioning work, costing time and contributing to false “azd” troubleshooting reports._